### PR TITLE
LPS-117287 If SPA is enabled, prevent multiple clicks on navigatable links (Showcase)

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/liferay/init.es.js
@@ -15,7 +15,7 @@
 'use strict';
 
 import {async} from 'metal';
-import {match} from 'metal-dom';
+import {delegate, match} from 'metal-dom';
 import {utils, version} from 'senna';
 import globals from 'senna/lib/globals/globals';
 
@@ -123,6 +123,22 @@ const initSPA = function () {
 			}
 		});
 	};
+
+	delegate(document, 'click', 'a', (event) => {
+		console.log('click ' + event.detail);
+
+		const url = event.delegateTarget.href;
+
+		if (event.detail > 1 && app.canNavigate(url)) {
+			console.log('preventing default for click ' + event.detail);
+
+			event.preventDefault();
+		}
+	});
+
+	delegate(document, 'dblclick', 'a', (event) => {
+		console.log('raw double click event');
+	});
 
 	Liferay.initComponentCache();
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
@@ -393,6 +393,9 @@ const MillerColumnsItem = ({
 						displayType="secondary"
 						href={action.url}
 						monospaced
+						onDoubleClick={() => {
+							console.log('react onDoubleClick event');
+						}}
 						outline
 					>
 						<ClayIcon symbol={action.icon} />


### PR DESCRIPTION
Case 1: Double-click to open a web content link. This is a navigatable link, so we prevent second navigation. Raw dblclick event triggers.
Case 2: Double-click bold text icon. Bold icon is not a navigatable link, so we are **not** preventing second click. Raw dblclick event triggers.
Case 3: Double-click on cog icon on layouts page. This is a `ClayLink` component with `onDoubleClick` defined, it triggers. Raw dblclick event also triggers.

![dblclick](https://user-images.githubusercontent.com/5435511/92730479-20301780-f374-11ea-9db5-ca889bea072d.gif)
 